### PR TITLE
tests(domain): Add tests for TodoItem and Tag entities

### DIFF
--- a/Tsk.Tests/Entities/Tag.cs
+++ b/Tsk.Tests/Entities/Tag.cs
@@ -1,0 +1,49 @@
+using Xunit;
+using Bogus;
+using Tsk.Domain.Entities;
+
+namespace Tsk.Tests.Entities
+{
+    public class TagTests
+    {
+        [Fact]
+        public void ShouldThrow_With_Comma()
+        {
+            var faker = new Faker<Tag>()
+                .CustomInstantiator(
+                    f => new Tag(name: f.Random.String(4) + "," + f.Random.String())
+                );
+            Assert.Throws<ArgumentException>(() => faker.Generate());
+        }
+
+        [Fact]
+        public void ShouldThrow_With_LineBreak()
+        {
+            var faker = new Faker<Tag>()
+                .CustomInstantiator(
+                    f => new Tag(name: f.Random.String(4) + "\r")
+                );
+            Assert.Throws<ArgumentException>(() => faker.Generate());
+        }
+
+        [Fact]
+        public void ShouldThrow_With_TooLong()
+        {
+            var faker = new Faker<Tag>()
+                .CustomInstantiator(
+                    f => new Tag(name: f.Random.String(50))
+                );
+            Assert.Throws<ArgumentException>(() => faker.Generate());
+        }
+
+        [Fact]
+        public void ShouldThrow_Blank()
+        {
+            var faker = new Faker<Tag>()
+                .CustomInstantiator(
+                    f => new Tag(name: string.Empty)
+                );
+            Assert.Throws<ArgumentNullException>(() => faker.Generate());
+        }
+    }
+}

--- a/Tsk.Tests/Entities/TodoItem.cs
+++ b/Tsk.Tests/Entities/TodoItem.cs
@@ -1,0 +1,122 @@
+using Bogus;
+using Tsk.Domain.Entities;
+
+namespace Tsk.Tests.Entities
+{
+    public class TodoItemTests
+    {
+        [Fact]
+        public void ShouldThrow_Description_Blank()
+        {
+            var faker = new Faker<TodoItem>()
+                .CustomInstantiator(
+                    f => new TodoItem(id: f.Random.Int(), description: string.Empty)
+                );
+            Assert.Throws<ArgumentNullException>(
+                () => new TodoItem(id: 1, description: "")
+            );
+        }
+
+        [Fact]
+        public void ShouldThrow_Description_TooLong()
+        {
+            Faker<TodoItem> faker = new Faker<TodoItem>()
+                .CustomInstantiator(
+                    f => new TodoItem(id: f.Random.Int(), description: f.Random.String(100))
+                );
+            Assert.Throws<ArgumentException>(
+                () => faker.Generate()
+            );
+        }
+
+        [Fact]
+        public void ShouldThrow_Description_LineBreaks()
+        {
+            var faker = new Faker<TodoItem>()
+                .CustomInstantiator(
+                    f => new TodoItem(id: f.Random.Int(), description: f.Random.String(10) + "\n")
+                );
+            Assert.Throws<ArgumentException>(
+                () => faker.Generate()
+            );
+        }
+
+        [Fact]
+        public void ShouldThrow_Location_Commas()
+        {
+            var faker = new Faker<TodoItem>()
+                .CustomInstantiator(
+                    f => new TodoItem(
+                        id: f.Random.Int(),
+                        description: f.Random.String(10),
+                        location: "Rondebosch,Common"
+                    )
+                );
+            Assert.Throws<ArgumentException>(
+                () => faker.Generate()
+            );
+        }
+
+        [Fact]
+        public void ShouldThrow_Location_LineBreaks()
+        {
+            var faker = new Faker<TodoItem>()
+                .CustomInstantiator(
+                    f => new TodoItem(
+                        id: f.Random.Int(),
+                        description: f.Random.String(10),
+                        location: "Rondebosch\n"
+                    )
+                );
+            Assert.Throws<ArgumentException>(
+                () => faker.Generate()
+            );
+        }
+
+        [Fact]
+        public void ShouldThrow_Location_TooLong()
+        {
+            var faker = new Faker<TodoItem>()
+                .CustomInstantiator(
+                    f => new TodoItem(
+                        id: f.Random.Int(),
+                        description: f.Random.String(10),
+                        location: f.Random.String(50)
+                    )
+                );
+            Assert.Throws<ArgumentException>(
+                () => faker.Generate()
+            );
+        }
+
+        [Fact]
+        public void ShoulNotThrow_Without_Location()
+        {
+            var faker = new Faker<TodoItem>()
+                .CustomInstantiator(
+                    f => new TodoItem(
+                        id: f.Random.Int(),
+                        description: f.Random.String(20),
+                        location: null
+                    )
+                );
+            var exception = Record.Exception(() => faker.Generate());
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void ShoulNotThrow_With_Location()
+        {
+            var faker = new Faker<TodoItem>()
+                .CustomInstantiator(
+                    f => new TodoItem(
+                        id: f.Random.Int(),
+                        description: f.Random.String(20),
+                        location: f.Address.City()
+                    )
+                );
+            var exception = Record.Exception(() => faker.Generate());
+            Assert.Null(exception);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds tests for the `TodoItem` and `Tag` input validations.