### PR TITLE
fix(domain): Make DueDate nullable

### DIFF
--- a/Tsk.Domain/Entities/TodoItem.cs
+++ b/Tsk.Domain/Entities/TodoItem.cs
@@ -16,7 +16,7 @@ namespace Tsk.Domain.Entities
             }
         }
         public DateOnly? DueDate { get; private set; }
-        public bool Completed { get; set; }
+        public bool Completed { get; set; } = false;
         public string? Location { get; set; } = string.Empty;
 
         private List<Tag> _tags = new();
@@ -31,9 +31,7 @@ namespace Tsk.Domain.Entities
             Description = input;
         }
 
-        public void UpdateDueDate(DateOnly dueDate) => DueDate = dueDate;
-
-        public void RemoveDueDate() => DueDate = null;
+        public void UpdateDueDate(DateOnly? dueDate) => DueDate = dueDate;
 
         public void UpdateLocation(string? location)
         {


### PR DESCRIPTION
This PR makes `DueDate` nullable. As a result, the API can be streamlined by removing `RemoveDueDate()`, as the date can just be set to `null`.