### PR TITLE
feat(domain): Add `dueDate` checking in `Deserialize`

### DIFF
--- a/Tsk.Tests/Serialization/TodoItemFlatFileDeserialize.cs
+++ b/Tsk.Tests/Serialization/TodoItemFlatFileDeserialize.cs
@@ -91,5 +91,12 @@ namespace Tsk.Tests.Serialization
             Assert.All(tags, u => result.Tags.Any(t => t.Name == u));
 
         }
+
+        [Fact]
+        public void ShouldError_WithBadDate()
+        {
+            var line = @"[X] 20259999 ""buy milk""";
+            Assert.Throws<FormatException>(() => serializer.Deserialize(line, 1));
+        }
     }
 }


### PR DESCRIPTION
This PR adds:

- error checking for `dueDate` in `Deserialize()`
- error checking for `<matches>` in `Deserialize()`
- test case for bad date deserialization
- clean up of unused, commented-out Regex strings