### PR TITLE
refactor(domain): Clean up TodoItem; add Tags to constructor

### DIFF
--- a/Tsk.Domain/Entities/TodoItem.cs
+++ b/Tsk.Domain/Entities/TodoItem.cs
@@ -5,6 +5,7 @@ namespace Tsk.Domain.Entities
     public class TodoItem
     {
         public int Id { get; set; }
+
         private string _description = string.Empty;
         public string Description
         {
@@ -15,35 +16,32 @@ namespace Tsk.Domain.Entities
                 _description = value;
             }
         }
-        public DateOnly? DueDate { get; private set; }
-        public bool Completed { get; set; } = false;
-        public string? Location { get; set; } = string.Empty;
-
-        private List<Tag> _tags = new();
-        public IReadOnlyList<Tag> Tags { get => _tags; }
-
-        public void MarkComplete() => Completed = true;
-        public void MarkIncomplete() => Completed = false;
-
         public void UpdateDescription(string input)
         {
             Input.ValidateDescription(input);
             Description = input;
         }
 
+        public DateOnly? DueDate { get; private set; } = null;
         public void UpdateDueDate(DateOnly? dueDate) => DueDate = dueDate;
 
+        public bool Completed { get; private set; } = false;
+        public void MarkComplete() => Completed = true;
+        public void MarkIncomplete() => Completed = false;
+
+        public string? Location { get; private set; } = string.Empty;
         public void UpdateLocation(string? location)
         {
             Input.ValidateLocation(location ?? "");
             Location = location;
         }
 
+        private List<Tag> _tags = new();
+        public IReadOnlyList<Tag> Tags { get => _tags; }
         public void AddTag(Tag tag)
         {
             if (!Tags.Any(t => t.Name == tag.Name)) _tags.Add(tag);
         }
-
         public void RemoveTag(Tag tag) =>
             _tags.RemoveAll(t => t.Name == tag.Name);
 
@@ -51,13 +49,21 @@ namespace Tsk.Domain.Entities
             int id,
             string description,
             string? location = null,
-            DateOnly? dueDate = null
+            DateOnly? dueDate = null,
+            IEnumerable<Tag>? tags = null
         )
         {
             Id = id;
             UpdateDescription(description);
             if (dueDate is not null) UpdateDueDate(dueDate.Value);
             if (location is not null) UpdateLocation(location);
+            if (tags is not null)
+            {
+                foreach (var tag in tags)
+                {
+                    AddTag(tag);
+                }
+            }
         }
 
         public override string ToString() => Description;


### PR DESCRIPTION
This PR cleans up the TodoItem class, group related functionality together.

It also allows for passing tags directly into the constructor.

It also ensures all fields are set privately, only allowing setting through methods (e.g. `UpdateDueDate()`) for consistent API.