### PR TITLE
feat(infra): Implement FlatFileTodoRepository

### DIFF
--- a/Tsk.Domain/Entities/TodoItem.cs
+++ b/Tsk.Domain/Entities/TodoItem.cs
@@ -29,7 +29,7 @@ namespace Tsk.Domain.Entities
         public void MarkComplete() => Completed = true;
         public void MarkIncomplete() => Completed = false;
 
-        public string? Location { get; private set; } = string.Empty;
+        public string? Location { get; private set; } = null;
         public void UpdateLocation(string? location)
         {
             Input.ValidateLocation(location ?? "");

--- a/Tsk.Domain/Repositories/ITodoRepository.cs
+++ b/Tsk.Domain/Repositories/ITodoRepository.cs
@@ -7,7 +7,7 @@ namespace Tsk.Domain.Repositories
         IEnumerable<TodoItem> GetAll();
         TodoItem? GetById(int id);
         void Add(TodoItem todoItem);
-        void Update(TodoItem todoItem);
+        void Save(TodoItem todoItem);
         void Delete(TodoItem todoItem);
     }
 }

--- a/Tsk.Domain/Repositories/ITodoRepository.cs
+++ b/Tsk.Domain/Repositories/ITodoRepository.cs
@@ -7,7 +7,7 @@ namespace Tsk.Domain.Repositories
         IEnumerable<TodoItem> GetAll();
         TodoItem? GetById(int id);
         void Add(TodoItem todoItem);
-        void Save(TodoItem todoItem);
+        void Save(TodoItem todoItem); // not needed for flat file
         void Delete(TodoItem todoItem);
     }
 }

--- a/Tsk.Infrastructure/FileIO/FileReaderWriter.cs
+++ b/Tsk.Infrastructure/FileIO/FileReaderWriter.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Tsk.Infrastructure.FileIO
+{
+    public class FileReaderWriter : IFileReaderWriter
+    {
+        public IEnumerable<string> ReadAllLines(string path) =>
+            File.ReadAllLines(path);
+
+        public void WriteAllLines(string path, IEnumerable<string> lines) =>
+            File.WriteAllLines(path, lines);
+    }
+}

--- a/Tsk.Infrastructure/FileIO/IFileReaderWriter.cs
+++ b/Tsk.Infrastructure/FileIO/IFileReaderWriter.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Tsk.Infrastructure.FileIO
+{
+    public interface IFileReaderWriter
+    {
+        IEnumerable<string> ReadAllLines(string path);
+        void WriteAllLines(string path, IEnumerable<string> lines);
+    }
+}

--- a/Tsk.Infrastructure/Repositories/FlatFileTodoRepository.cs
+++ b/Tsk.Infrastructure/Repositories/FlatFileTodoRepository.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Tsk.Domain.Entities;
 using Tsk.Domain.Repositories;
@@ -62,7 +63,9 @@ namespace Tsk.Infrastructure.Repositories
 
         public void Save(TodoItem todoItem)
         {
-            // NOTE: Save file
+            if (_list is null) throw new ArgumentNullException("List is not initialized!");
+            string[] data = _list.Select(u => _serializer.Serialize(u)).ToArray();
+            _fileIO.WriteAllLines(_filepath, data);
         }
     }
 }

--- a/Tsk.Infrastructure/Repositories/FlatFileTodoRepository.cs
+++ b/Tsk.Infrastructure/Repositories/FlatFileTodoRepository.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Tsk.Domain.Entities;
+using Tsk.Domain.Repositories;
+using Tsk.Domain.Serialization;
+using Tsk.Infrastructure.FileIO;
+
+namespace Tsk.Infrastructure.Repositories
+{
+    public class FlatFileTodoRepository : ITodoRepository
+    {
+        private string _filepath;
+        private IFileReaderWriter _fileIO;
+        private List<TodoItem>? _list = null;
+        private List<Tag> _tags = new();
+        private TodoItemFlatFileSerializer _serializer = new();
+
+
+        public FlatFileTodoRepository(string filePath, IFileReaderWriter fileIO)
+        {
+            _filepath = filePath;
+            _fileIO = fileIO;
+        }
+
+        public void LoadTodos()
+        {
+            _list = new();
+            var lines = _fileIO.ReadAllLines(_filepath);
+            var lineNum = 1;
+            foreach (var line in lines)
+            {
+                TodoItem todo = _serializer.Deserialize(line, lineNum++);
+                _list.Add(todo);
+            }
+            foreach (var todo in _list)
+                foreach (var tag in todo.Tags)
+                    if (!_tags.Any(t => t.Name == tag.Name)) _tags.Add(tag);
+        }
+
+        public void Add(TodoItem todoItem) => _list?.Add(todoItem);
+
+        public void Delete(TodoItem todoItem)
+        {
+            _list?.RemoveAll(t => t.Id == todoItem.Id);
+        }
+
+        public IEnumerable<TodoItem> GetAll()
+        {
+            if (_list is null)
+                throw new NullReferenceException("List is null; did you for get to `LoadTodos`?");
+            return _list;
+        }
+
+        public IEnumerable<Tag> GetAllTags() => _tags;
+
+        public TodoItem? GetById(int id) => _list?.Find(t => t.Id == id);
+
+        public IEnumerable<TodoItem>? GetTodosByTag(string tag) =>
+            _list?.FindAll(t => t.Tags.Any(u => u.Name == tag));
+
+        public void Save(TodoItem todoItem)
+        {
+            // NOTE: Save file
+        }
+    }
+}

--- a/Tsk.Infrastructure/Repositories/FlatFileTodoRepository.cs
+++ b/Tsk.Infrastructure/Repositories/FlatFileTodoRepository.cs
@@ -61,7 +61,10 @@ namespace Tsk.Infrastructure.Repositories
         public IEnumerable<TodoItem>? GetTodosByTag(string tag) =>
             _list?.FindAll(t => t.Tags.Any(u => u.Name == tag));
 
-        public void Save(TodoItem todoItem)
+        // Not needed for flat file; including for potential extension to SQL
+        public void Save(TodoItem todoItem) {}
+
+        public void SaveToFile()
         {
             if (_list is null) throw new ArgumentNullException("List is not initialized!");
             string[] data = _list.Select(u => _serializer.Serialize(u)).ToArray();

--- a/Tsk.Tests/Repositories/FlatFileTodoRepository.cs
+++ b/Tsk.Tests/Repositories/FlatFileTodoRepository.cs
@@ -91,5 +91,60 @@ namespace Tsk.Tests.Repositories
             var fileRepository = new FlatFileTodoRepository(path, mockFile.Object);
             Assert.Throws<FormatException>(() => fileRepository.LoadTodos());
         }
+
+        [Fact]
+        public void ShouldLoadFromFile()
+        {
+            string path = TestHelpers.ResolveFromSlnRoot("Tsk.Tests", "TestData", "TestInputFile1.txt");
+
+            var fileRepository = new FlatFileTodoRepository(path, new FileReaderWriter());
+            fileRepository.LoadTodos();
+            var result = fileRepository.GetAll().ToList();
+            Assert.Equal(3, result.Count());
+        }
+
+        [Fact]
+        public void ShouldGetTags()
+        {
+            var path = "somefile.txt";
+            string[] lines =
+                [
+                    "[ ] 20250425 \"buy milk\" loc:\"Cape Town\" tags:shopping,errands",
+                    "[X] 20250426 \"go for a walk\" loc:Alphen tags:fitness,out-and-about",
+                    "[ ] \"complete assignment\""
+                ];
+            var mockFile = new Mock<IFileReaderWriter>();
+            mockFile.Setup(f => f.ReadAllLines(path)).Returns(lines);
+            var fileRepository = new FlatFileTodoRepository(path, mockFile.Object);
+            fileRepository.LoadTodos();
+            var result = fileRepository.GetAllTags().ToList();
+            Assert.Equal(4, result.Count());
+            string[] tags = ["shopping", "errands", "fitness", "out-and-about"];
+            foreach (var t in result)
+            {
+                Assert.Contains(t.Name, tags);
+            }
+            Assert.Equal(4, result.Count());
+        }
+
+        [Fact]
+        public void ShouldGetOneTagById()
+        {
+            var path = "somefile.txt";
+            string[] lines =
+                [
+                    "[ ] 20250425 \"buy milk\" loc:\"Cape Town\" tags:shopping,errands",
+                    "[X] 20250426 \"go for a walk\" loc:Alphen tags:fitness,out-and-about",
+                    "[ ] \"complete assignment\""
+                ];
+            var mockFile = new Mock<IFileReaderWriter>();
+            mockFile.Setup(f => f.ReadAllLines(path)).Returns(lines);
+            var fileRepository = new FlatFileTodoRepository(path, mockFile.Object);
+            fileRepository.LoadTodos();
+            var result = fileRepository.GetTodosByTag("fitness")?.ToList();
+            Assert.Equal(1, result?.Count);
+            Assert.Equal(2, result?[0].Id);
+            Assert.Equal("go for a walk", result?[0].Description);
+        }
     }
 }

--- a/Tsk.Tests/Repositories/FlatFileTodoRepository.cs
+++ b/Tsk.Tests/Repositories/FlatFileTodoRepository.cs
@@ -1,0 +1,95 @@
+using Moq;
+using Tsk.Domain.Entities;
+using Tsk.Domain.Serialization;
+using Tsk.Infrastructure.FileIO;
+using Tsk.Infrastructure.Repositories;
+using Tsk.Tests.TestSupport;
+using Xunit.Sdk;
+
+namespace Tsk.Tests.Repositories
+{
+    public class FlatFileTodoRepositoryTests
+    {
+        public TodoItemFlatFileSerializer serializer = new();
+
+        [Fact]
+        public void ShouldLoadTodosFromMockedString()
+        {
+            var path = "somefile";
+            var todo1 = new TodoItem(id: 1, description: "buy milk");
+            todo1.MarkComplete();
+            var todo2 = new TodoItem(id: 2, description: "go for a run");
+            var todo3 = new TodoItem(id: 3, description: "win");
+            List<TodoItem> todos = new() { todo1, todo2, todo3 };
+            var lines = new TodoItem[] { todo1, todo2, todo3 }
+                .Select(u => serializer.Serialize(u));
+
+
+            var mockFile = new Mock<IFileReaderWriter>();
+            mockFile.Setup(f => f.ReadAllLines(path)).Returns(lines);
+
+            var fileRepository = new FlatFileTodoRepository(path, mockFile.Object);
+            fileRepository.LoadTodos();
+
+            var result = fileRepository.GetAll().ToList();
+
+            foreach (var t in todos)
+            {
+                var r = result.Find(u => u.Id == t.Id);
+                Assert.Equal(t.Description, r!.Description);
+                Assert.Equal(t.Completed, r!.Completed);
+            }
+        }
+
+        [Fact]
+        public void ShouldLoad_With_Full_Example()
+        {
+            var path = "somefile.txt";
+            string[] lines =
+                [
+                    "[ ] 20250425 \"buy milk\" loc:\"Cape Town\" tags:shopping,errands",
+                    "[X] 20250426 \"go for a walk\" loc:Alphen tags:fitness,out-and-about",
+                    "[ ] \"complete assignment\""
+                ];
+            var mockFile = new Mock<IFileReaderWriter>();
+            mockFile.Setup(f => f.ReadAllLines(path)).Returns(lines);
+            var fileRepository = new FlatFileTodoRepository(path, mockFile.Object);
+            fileRepository.LoadTodos();
+            var result = fileRepository.GetAll();
+            var r1 = result.ToList().Find(u => u.Id == 1);
+            var r2 = result.ToList().Find(u => u.Id == 2);
+            var r3 = result.ToList().Find(u => u.Id == 3);
+
+            Assert.Equal("buy milk", r1!.Description);
+            Assert.Equal("Cape Town", r1.Location);
+            Assert.Equal("shopping", r1.Tags[0].Name);
+            Assert.Equal("errands", r1.Tags[1].Name);
+            Assert.Equivalent(new DateOnly(2025, 04, 25), r1.DueDate);
+            Assert.False(r1.Completed);
+
+            Assert.Equal("go for a walk", r2!.Description);
+            Assert.Equal("Alphen", r2.Location);
+            Assert.Equal("fitness", r2.Tags[0].Name);
+            Assert.Equal("out-and-about", r2.Tags[1].Name);
+            Assert.Equivalent(new DateOnly(2025, 04, 26), r2.DueDate);
+            Assert.True(r2.Completed);
+
+            Assert.Equal("complete assignment", r3!.Description);
+            Assert.Null(r3.Location);
+            Assert.Empty(r3.Tags);
+            Assert.Null(r3.DueDate);
+            Assert.False(r3.Completed);
+        }
+
+        [Fact]
+        public void ShouldError_With_Bad_Input()
+        {
+            string path = "somefile.txt";
+            var line = @"[ ] 12342 asdf asdf";
+            var mockFile = new Mock<IFileReaderWriter>();
+            mockFile.Setup(f => f.ReadAllLines(path)).Returns([line]);
+            var fileRepository = new FlatFileTodoRepository(path, mockFile.Object);
+            Assert.Throws<FormatException>(() => fileRepository.LoadTodos());
+        }
+    }
+}

--- a/Tsk.Tests/TestData/TestInputFile1.txt
+++ b/Tsk.Tests/TestData/TestInputFile1.txt
@@ -1,0 +1,3 @@
+[ ] "buy milk"
+[X] "do grocery run" loc:"Blue Route" tags:shopping,errands
+[ ] 20240501 "go for a walk" loc:Alphen tags:fitness,out-and-about

--- a/Tsk.Tests/TestSupport/TestHelpers.cs
+++ b/Tsk.Tests/TestSupport/TestHelpers.cs
@@ -9,5 +9,20 @@ namespace Tsk.Tests.TestSupport
     {
         public static string Enq(string input) =>
             input.Contains(" ") ? $"\"{input}\"" : input;
+
+        public static string ResolveFromSlnRoot(params string[] relativeSegments)
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+
+            while (dir != null && !File.Exists(Path.Combine(dir.FullName, "Tsk.slnx")))
+            {
+                dir = dir.Parent;
+            }
+
+            if (dir == null)
+                throw new DirectoryNotFoundException("Could not find the solution root containing Tsk.slnx");
+
+            return Path.Combine(new[] { dir.FullName }.Concat(relativeSegments).ToArray());
+        }
     }
 }

--- a/Tsk.Tests/Tsk.Tests.csproj
+++ b/Tsk.Tests/Tsk.Tests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Bogus" Version="35.6.3" />
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>


### PR DESCRIPTION
This (big) PR completes the core functionality of the Tsk logic. It adds:

- `IFileReaderWriter` interface for repository disk access
- `FileReaderWriter` class for actually accessing the file on disk
- `FlatFileTodoRepository` which implements `ITodoRepository` in domain

It includes tests, including mocking for file reading, as well as integration tests which read data from an actual file on disk.