### PR TITLE
feat(cli): Initialize CLI project

### DIFF
--- a/Tsk.CLI/Program.cs
+++ b/Tsk.CLI/Program.cs
@@ -1,0 +1,11 @@
+﻿using Tsk.CLI.Utils;
+
+namespace Tsk.CLI;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        System.Console.WriteLine(AppData.GetDefaultTskPath());
+    }
+}

--- a/Tsk.CLI/Tsk.CLI.csproj
+++ b/Tsk.CLI/Tsk.CLI.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Tsk.Domain\Tsk.Domain.csproj" />
+    <ProjectReference Include="..\Tsk.Infrastructure\Tsk.Infrastructure.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Bogus" Version="35.6.3" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Tsk.CLI/Utils/AppData.cs
+++ b/Tsk.CLI/Utils/AppData.cs
@@ -1,0 +1,20 @@
+namespace Tsk.CLI.Utils
+{
+    public class AppData
+    {
+        public static string GetDefaultTskPath(string tskFileName = "tsk.txt") =>
+            Path.Combine(
+                OperatingSystem.IsWindows()
+                ? Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)
+                : OperatingSystem.IsMacOS()
+                ? Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                    "Library",
+                    "Application Support"
+                )
+                : Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "tsk",
+                tskFileName
+            );
+    }
+}

--- a/Tsk.Tests/CliUtils/AppDataTests.cs
+++ b/Tsk.Tests/CliUtils/AppDataTests.cs
@@ -1,0 +1,45 @@
+using System.Text.RegularExpressions;
+using Tsk.CLI.Utils;
+
+namespace Tsk.Tests.CliUtils
+{
+    public class AppDataTests
+    {
+        [Fact]
+        public void ShouldReturnCorrectDefaultTskPath()
+        {
+            var result = AppData.GetDefaultTskPath();
+            if (OperatingSystem.IsWindows())
+            {
+                Assert.EndsWith(@"\AppData\Roaming\tsk\tsk.txt", result);
+            }
+            else if (OperatingSystem.IsMacOS())
+            {
+                Assert.EndsWith(@"Library/Application Support/tsk/tsk.txt", result);
+            }
+            else
+            {
+                Assert.EndsWith(@".local/share/tsk/tsk.txt", result);
+            }
+        }
+
+        [Fact]
+        public void ShouldReturnCustomTskFilename()
+        {
+            var filename = "custom-filename.txt";
+            var result = AppData.GetDefaultTskPath(filename);
+            if (OperatingSystem.IsWindows())
+            {
+                Assert.EndsWith($"\\AppData\\Roaming\\tsk\\{filename}", result);
+            }
+            else if (OperatingSystem.IsMacOS())
+            {
+                Assert.EndsWith($"Library/Application Support/tsk/{filename}", result);
+            }
+            else
+            {
+                Assert.EndsWith($".local/share/tsk/{filename}", result);
+            }
+        }
+    }
+}

--- a/Tsk.Tests/Tsk.Tests.csproj
+++ b/Tsk.Tests/Tsk.Tests.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Tsk.Domain\Tsk.Domain.csproj" />
     <ProjectReference Include="..\Tsk.Infrastructure\Tsk.Infrastructure.csproj" />
+    <ProjectReference Include="..\Tsk.CLI\Tsk.CLI.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Tsk.slnx
+++ b/Tsk.slnx
@@ -4,6 +4,7 @@
     <Platform Name="x64" />
     <Platform Name="x86" />
   </Configurations>
+  <Project Path="Tsk.CLI/Tsk.CLI.csproj" />
   <Project Path="Tsk.Domain/Tsk.Domain.csproj" />
   <Project Path="Tsk.Infrastructure/Tsk.Infrastructure.csproj" />
   <Project Path="Tsk.Tests/Tsk.Tests.csproj" />


### PR DESCRIPTION
This PR initializes the CLI project, adding it to the solution file, and adding `Tsk.Domain` and `Tsk.Infrastruccture` as references.

The CLI will need to access the user's default application storage path. This commit adds an `AppData` with the `GetDefaultTskPath()` static method that returns this path based on the user's OS.