### PR TITLE
feat(infra): Add TodoRepositoryFactory

### DIFF
--- a/Tsk.Domain/Factories/ITodoRepositoryFactory.cs
+++ b/Tsk.Domain/Factories/ITodoRepositoryFactory.cs
@@ -1,0 +1,9 @@
+using Tsk.Domain.Repositories;
+
+namespace Tsk.Domain.Factories
+{
+    public interface ITodoRepositoryFactory
+    {
+        ITodoRepository Create(string path);
+    }
+}

--- a/Tsk.Infrastructure/Factories/FlatFileTodoRepositoryFactory.cs
+++ b/Tsk.Infrastructure/Factories/FlatFileTodoRepositoryFactory.cs
@@ -1,0 +1,18 @@
+using Tsk.Domain.Factories;
+using Tsk.Domain.Repositories;
+using Tsk.Infrastructure.FileIO;
+using Tsk.Infrastructure.Repositories;
+
+namespace Tsk.Infrastructure.Factories
+{
+    public class FlatFileTodoRepositoryFactory : ITodoRepositoryFactory
+    {
+        public ITodoRepository Create(string path) 
+        {
+            var fileIO = new FileReaderWriter();
+            var repo = new FlatFileTodoRepository(path, fileIO);
+            repo.LoadTodos();
+            return repo;
+        }
+    }
+}

--- a/Tsk.Tests/Factories/FlatFileTodoRepositoryFactoryTests.cs
+++ b/Tsk.Tests/Factories/FlatFileTodoRepositoryFactoryTests.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Tsk.Domain.Entities;
+using Tsk.Infrastructure.Factories;
+using Tsk.Tests.TestSupport;
+using Xunit;
+
+namespace Tsk.Tests.Factories
+{
+    public class FlatFileTodoRepositoryFactoryTests
+    {
+        [Fact]
+        public void ShouldCreate_FlatFileTodoRepository()
+        {
+            var fileName = TestHelpers.ResolveFromSlnRoot("Tsk.Tests", "TestData", "TestInputFile1.txt");
+            var repo = new FlatFileTodoRepositoryFactory().Create(fileName);
+            var list = repo.GetAll();
+            Assert.Equal(3, list.Count());
+            Assert.True(list.All(u => u is TodoItem));
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the `ITodoRepositoryFactory` interface, as well as its implementation, the `FlatFileTodoRepositoryFactory`.

The need for this became apparent once I explored `Spectre.Console.Cli`. A feature of Tsk is for the user to optionally specify a custom file location. This means that the TodoRepository cannot be initialized before Spectre.Console has had a chance to parse the command line arguments.

Thankfully, there is a workaround, and that is to use a DI Container, and to pass in a factory for the repository, so that the repository can be instantiated with the correct path.