### PR TITLE
refactor(cli): Extract rendering to TodoListRenderer class

### DIFF
--- a/Tsk.CLI/Application/Commands/BaseCommand.cs
+++ b/Tsk.CLI/Application/Commands/BaseCommand.cs
@@ -1,10 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Threading.Tasks;
 using Spectre.Console.Cli;
-using Tsk.CLI.Application.Settings;
 using Tsk.CLI.Utils;
 using Tsk.Domain.Factories;
 using Tsk.Domain.Repositories;
@@ -14,31 +8,31 @@ namespace Tsk.CLI.Application.Commands
     public abstract class BaseCommand<TSettings>
         : Command<TSettings> where TSettings : CommandSettings
     {
-        protected ITodoRepository? _repo;
+        private ITodoRepository? _repo;
+        protected ITodoRepository Repo => _repo ?? throw new InvalidOperationException("Repository is not initialized!");
 
-        protected void Init(string? path, ITodoRepositoryFactory factory)
+        protected void InitRepository(string? path, ITodoRepositoryFactory factory)
         {
-            string _path = AppData.GetTskPath(path);
+            string resolvedPath = AppData.GetTskPath(path);
 
             try
             {
-                Helpers.EnsureTskFile(_path);
-                _repo = factory.Create(_path);
+                Helpers.EnsureTskFile(resolvedPath);
+                _repo = factory.Create(resolvedPath);
             }
             catch (DirectoryNotFoundException)
             {
-                var message = $"Directory {Path.GetDirectoryName(_path)} does not exist!";
-                if (path is not null && path.Contains("$"))
+                var message = $"Directory {Path.GetDirectoryName(resolvedPath)} does not exist!";
+                if (path is not null && path.Contains('$'))
                     message += " It seems like you're trying to use a $variable; please make sure it is resolving correctly.";
-                System.Console.WriteLine(message);
+                Console.WriteLine(message);
                 Environment.Exit(1);
             }
             catch (UnauthorizedAccessException)
             {
-                System.Console.WriteLine($"You do not have permission to write to {path}");
+                Console.WriteLine($"You do not have permission to write to {path}");
                 Environment.Exit(1);
             }
-
         }
     }
 }

--- a/Tsk.CLI/Application/Commands/ListCommand.cs
+++ b/Tsk.CLI/Application/Commands/ListCommand.cs
@@ -1,8 +1,7 @@
 using Spectre.Console.Cli;
 using Tsk.Domain.Factories;
-using Tsk.Domain.Repositories;
 using Tsk.CLI.Application.Settings;
-using Spectre.Console;
+using Tsk.CLI.Presentation;
 
 namespace Tsk.CLI.Application.Commands
 {
@@ -14,45 +13,18 @@ namespace Tsk.CLI.Application.Commands
 
         public override int Execute(CommandContext context, Settings settings)
         {
-            Init(settings.FileName, _factory);
-            var list = _repo!.GetAll().ToList();
-            if (list.Count == 0)
+            InitRepository(settings.FileName, _factory);
+            try
             {
-                AnsiConsole.WriteLine("Your list is empty.");
+                TodoListRenderer.Render(Repo.GetAll());
                 return 0;
             }
-            var grid = new Grid();
-            Style headingStyle = new Style(foreground: Color.Yellow, decoration: Decoration.Underline);
-            Text[] headings = {
-                new Text("Status", headingStyle).LeftJustified(),
-                new Text("Description", headingStyle).LeftJustified(),
-                new Text("Due Date", headingStyle).LeftJustified(),
-                new Text("Tags", headingStyle).LeftJustified(),
-                new Text("Location", headingStyle).LeftJustified()
-            };
-            for (var i = 1; i <= 5; i++) grid.AddColumn();
-            grid.AddRow(
-                [.. headings.Select(h => new Padder(h)
-                    .PadTop(0)
-                    .PadRight(2)
-                    .PadBottom(0)
-                    .PadLeft(0)
-                )]
-            );
-            foreach (var t in list)
+            catch (Exception ex)
             {
-                grid.AddRow(new Text[]{
-                    new Text(t.Completed ? "X" : "").LeftJustified(),
-                    new Text(t.Description, t.Completed ? new Style(decoration: Decoration.Strikethrough): null).LeftJustified(),
-                    new Text(t.DueDate is not null? t.DueDate!.Value.ToString("yyyy-MM-dd") : "").LeftJustified(),
-                    new Text(t.Tags.Count > 0 ? string.Join("\n", t.Tags.Select(u => u.Name)) : "").LeftJustified(),
-                    new Text(t.Location ?? "").LeftJustified(),
-                });
+
+                System.Console.WriteLine(ex.Message);
+                return 1;
             }
-            AnsiConsole.Write(grid);
-            return 0;
-
-
         }
     }
 }

--- a/Tsk.CLI/Presentation/TodoListRenderer.cs
+++ b/Tsk.CLI/Presentation/TodoListRenderer.cs
@@ -1,0 +1,46 @@
+using Spectre.Console;
+using Tsk.Domain.Entities;
+
+namespace Tsk.CLI.Presentation
+{
+    public static class TodoListRenderer
+    {
+        public static void Render(IEnumerable<TodoItem> list)
+        {
+            if (!list.Any())
+            {
+                AnsiConsole.WriteLine("Your list is empty.");
+                return;
+            }
+            var grid = new Grid();
+            Style headingStyle = new Style(foreground: Color.Yellow, decoration: Decoration.Underline);
+            Text[] headings = {
+                new Text("Status", headingStyle).LeftJustified(),
+                new Text("Description", headingStyle).LeftJustified(),
+                new Text("Due Date", headingStyle).LeftJustified(),
+                new Text("Tags", headingStyle).LeftJustified(),
+                new Text("Location", headingStyle).LeftJustified()
+            };
+            for (var i = 1; i <= 5; i++) grid.AddColumn();
+            grid.AddRow(
+                [.. headings.Select(h => new Padder(h)
+                    .PadTop(0)
+                    .PadRight(2)
+                    .PadBottom(0)
+                    .PadLeft(0)
+                )]
+            );
+            foreach (var t in list)
+            {
+                grid.AddRow(new Text[]{
+                    new Text(t.Completed ? "X" : "").LeftJustified(),
+                    new Text(t.Description, t.Completed ? new Style(decoration: Decoration.Strikethrough): null).LeftJustified(),
+                    new Text(t.DueDate is not null? t.DueDate!.Value.ToString("yyyy-MM-dd") : "").LeftJustified(),
+                    new Text(t.Tags.Count > 0 ? string.Join("\n", t.Tags.Select(u => u.Name)) : "").LeftJustified(),
+                    new Text(t.Location ?? "").LeftJustified(),
+                });
+            }
+            AnsiConsole.Write(grid);
+        }
+    }
+}

--- a/Tsk.Infrastructure/Repositories/FlatFileTodoRepository.cs
+++ b/Tsk.Infrastructure/Repositories/FlatFileTodoRepository.cs
@@ -62,7 +62,7 @@ namespace Tsk.Infrastructure.Repositories
             _list?.FindAll(t => t.Tags.Any(u => u.Name == tag));
 
         // Not needed for flat file; including for potential extension to SQL
-        public void Save(TodoItem todoItem) {}
+        public void Save(TodoItem todoItem) { }
 
         public void SaveToFile()
         {


### PR DESCRIPTION
This PR extracts the rendering logic out of `ListCommand` into a new `TodoListRenderer` class. A future PR will add sorting logic / helpers to the renderer.

This PR also includes some light refactoring of `BaseCommand`. `protected _repo` has been replaced with `private _repo` and `protected Repo` which throws an exception if the repo has not been initialized yet.