### PR TITLE
feat(cli): Add `AddCommand`

### DIFF
--- a/Tsk.CLI/Application/Commands/AddCommand.cs
+++ b/Tsk.CLI/Application/Commands/AddCommand.cs
@@ -1,0 +1,79 @@
+using Spectre.Console.Cli;
+using Tsk.Domain.Factories;
+using Tsk.CLI.Application.Settings;
+using Tsk.CLI.Presentation;
+using System.ComponentModel;
+using Tsk.Domain.Entities;
+using Tsk.Domain.Validators;
+using Spectre.Console;
+
+namespace Tsk.CLI.Application.Commands
+{
+    public class AddCommand(ITodoRepositoryFactory factory) : BaseCommand<AddCommand.Settings>
+    {
+        private readonly ITodoRepositoryFactory _factory = factory;
+
+        public sealed class Settings : BaseCommandSettings
+        {
+            [Description("Set the todo description")]
+            [CommandArgument(0, "<description>")]
+            public string Description { get; set; } = string.Empty;
+
+            [Description($"Set the todo due date in yyyyMMdd format, e.g. 20250501")]
+            [CommandOption("-d|--date")]
+            public string? DueDate { get; set; }
+
+            [Description("Set the todo location")]
+            [CommandOption("-l|--loc")]
+            public string? Location { get; set; }
+
+            [Description("Set the todo tags in a comma-separated list")]
+            [CommandOption("-t|--tags")]
+            public string? Tags { get; set; }
+        }
+
+        public override int Execute(CommandContext context, Settings settings)
+        {
+            InitRepository(settings.FileName, _factory);
+            try
+            {
+                var id = Repo.GetAll().Count() + 1;
+                InputValidators.ValidateDescription(settings.Description);
+                var todo = new TodoItem(
+                    id: id,
+                    description: settings.Description
+                );
+                if (!string.IsNullOrEmpty(settings.Location))
+                {
+                    InputValidators.ValidateLocation(settings.Location);
+                    todo.UpdateLocation(settings.Location);
+                }
+                if (!string.IsNullOrEmpty(settings.Tags))
+                {
+
+                    var tags = settings.Tags.Split(",").Select(t => new Tag(t.Trim()));
+                    foreach (var t in tags)
+                        todo.AddTag(t);
+                }
+                if (settings.DueDate is not null)
+                {
+                    InputValidators.ValidateDateString(settings.DueDate);
+                    var yyyy = int.Parse(settings.DueDate.Substring(0, 4));
+                    var MM = int.Parse(settings.DueDate.Substring(4, 2));
+                    var dd = int.Parse(settings.DueDate.Substring(6, 2));
+                    todo.UpdateDueDate(new DateOnly(yyyy, MM, dd));
+                }
+
+                Repo.Add(todo);
+                Renderers.RenderSuccess($"Added \"{todo.Description}\"");
+                return 0;
+            }
+            catch (Exception ex)
+            {
+
+                Renderers.RenderError(ex.Message);
+                return 1;
+            }
+        }
+    }
+}

--- a/Tsk.CLI/Application/Commands/ListCommand.cs
+++ b/Tsk.CLI/Application/Commands/ListCommand.cs
@@ -16,7 +16,7 @@ namespace Tsk.CLI.Application.Commands
             InitRepository(settings.FileName, _factory);
             try
             {
-                TodoListRenderer.Render(Repo.GetAll());
+                Renderers.RenderTodoList(Repo.GetAll());
                 return 0;
             }
             catch (Exception ex)

--- a/Tsk.CLI/Presentation/Renderers.cs
+++ b/Tsk.CLI/Presentation/Renderers.cs
@@ -1,11 +1,12 @@
 using Spectre.Console;
+using Spectre.Console.Rendering;
 using Tsk.Domain.Entities;
 
 namespace Tsk.CLI.Presentation
 {
-    public static class TodoListRenderer
+    public static class Renderers
     {
-        public static void Render(IEnumerable<TodoItem> list)
+        public static void RenderTodoList(IEnumerable<TodoItem> list)
         {
             if (!list.Any())
             {
@@ -15,13 +16,14 @@ namespace Tsk.CLI.Presentation
             var grid = new Grid();
             Style headingStyle = new Style(foreground: Color.Yellow, decoration: Decoration.Underline);
             Text[] headings = {
+                new Text("Id", headingStyle).LeftJustified(),
                 new Text("Status", headingStyle).LeftJustified(),
                 new Text("Description", headingStyle).LeftJustified(),
                 new Text("Due Date", headingStyle).LeftJustified(),
                 new Text("Tags", headingStyle).LeftJustified(),
                 new Text("Location", headingStyle).LeftJustified()
             };
-            for (var i = 1; i <= 5; i++) grid.AddColumn();
+            for (var i = 0; i < headings.Length; i++) grid.AddColumn();
             grid.AddRow(
                 [.. headings.Select(h => new Padder(h)
                     .PadTop(0)
@@ -32,15 +34,23 @@ namespace Tsk.CLI.Presentation
             );
             foreach (var t in list)
             {
-                grid.AddRow(new Text[]{
-                    new Text(t.Completed ? "X" : "").LeftJustified(),
+                var row = new Text[]{
+                    new Text(t.Id.ToString()).LeftJustified(),
+                    new Text(t.Completed ? "X" : "O").LeftJustified(),
                     new Text(t.Description, t.Completed ? new Style(decoration: Decoration.Strikethrough): null).LeftJustified(),
                     new Text(t.DueDate is not null? t.DueDate!.Value.ToString("yyyy-MM-dd") : "").LeftJustified(),
                     new Text(t.Tags.Count > 0 ? string.Join("\n", t.Tags.Select(u => u.Name)) : "").LeftJustified(),
                     new Text(t.Location ?? "").LeftJustified(),
-                });
+                };
+                grid.AddRow([.. row.Select(r => new Padder(r).PadBottom(1).PadTop(0).PadRight(1).PadLeft(0))]);
             }
             AnsiConsole.Write(grid);
         }
+
+        public static void RenderError(string message) =>
+            AnsiConsole.Write(new Markup($"[red][bold]Error:[/][/] ${message}\n"));
+        
+        public static void RenderSuccess(string message) =>
+            AnsiConsole.Write(new Markup($"[green]Success![/] {message}\n"));
     }
 }

--- a/Tsk.CLI/Program.cs
+++ b/Tsk.CLI/Program.cs
@@ -11,7 +11,7 @@ namespace Tsk.CLI;
 
 class Program
 {
-    static void Main(string[] args)
+    static int Main(string[] args)
     {
         var registrations = new ServiceCollection();
         registrations.AddScoped<ITodoRepositoryFactory, FlatFileTodoRepositoryFactory>();
@@ -24,7 +24,10 @@ class Program
             config.SetApplicationVersion($"v{AppData.TskVersion}");
             config.AddCommand<ListCommand>("list")
                 .WithDescription("List tasks");
+            config.AddCommand<AddCommand>("add")
+                .WithDescription("Add a todo")
+                .WithExample([$"add \"buy milk\" --date {DateTime.Now.ToString("yyyyMMdd")} --loc \"Shoprite\" --tags shopping,errands"]);
         });
-        app.Run(args);
+        return app.Run(args);
     }
 }

--- a/Tsk.Domain/Entities/Tag.cs
+++ b/Tsk.Domain/Entities/Tag.cs
@@ -13,7 +13,7 @@ namespace Tsk.Domain.Entities
         {
             get => _name; set
             {
-                Input.ValidateTag(value);
+                InputValidators.ValidateTag(value);
                 _name = value.ToLower();
             }
         }

--- a/Tsk.Domain/Entities/TodoItem.cs
+++ b/Tsk.Domain/Entities/TodoItem.cs
@@ -12,13 +12,13 @@ namespace Tsk.Domain.Entities
             get => _description;
             protected set
             {
-                Input.ValidateDescription(value);
+                InputValidators.ValidateDescription(value);
                 _description = value;
             }
         }
         public void UpdateDescription(string input)
         {
-            Input.ValidateDescription(input);
+            InputValidators.ValidateDescription(input);
             Description = input;
         }
 
@@ -32,7 +32,7 @@ namespace Tsk.Domain.Entities
         public string? Location { get; private set; } = null;
         public void UpdateLocation(string? location)
         {
-            Input.ValidateLocation(location ?? "");
+            InputValidators.ValidateLocation(location ?? "");
             Location = location;
         }
 

--- a/Tsk.Domain/Validators/InputValidators.cs
+++ b/Tsk.Domain/Validators/InputValidators.cs
@@ -2,7 +2,7 @@ using Tsk.Domain.Validators.Utils;
 
 namespace Tsk.Domain.Validators
 {
-    public static class Input
+    public static class InputValidators
     {
         public static void ValidateTag(string input)
         {
@@ -22,10 +22,25 @@ namespace Tsk.Domain.Validators
 
         public static void ValidateDescription(string input)
         {
-            // Strings.NoCommas(input);
             Strings.NoLineBreaks(input);
             Strings.MaxLength(input, 50);
             Strings.NotWhiteSpace(input);
+        }
+
+        public static void ValidateDateString(string input)
+        {
+            try
+            {
+                new DateOnly(
+                    int.Parse(input.Substring(0, 4)),
+                    int.Parse(input.Substring(4, 2)),
+                    int.Parse(input.Substring(6, 2))
+                );
+            }
+            catch (Exception)
+            {
+                throw new ArgumentException($"Date `{input}` is not in the correct format (yyyyMMdd)");
+            }
         }
     }
 }

--- a/Tsk.Infrastructure/Repositories/FlatFileTodoRepository.cs
+++ b/Tsk.Infrastructure/Repositories/FlatFileTodoRepository.cs
@@ -40,7 +40,11 @@ namespace Tsk.Infrastructure.Repositories
                     if (!_tags.Any(t => t.Name == tag.Name)) _tags.Add(tag);
         }
 
-        public void Add(TodoItem todoItem) => _list?.Add(todoItem);
+        public void Add(TodoItem todoItem)
+        {
+            _list?.Add(todoItem);
+            SaveToFile();
+        }
 
         public void Delete(TodoItem todoItem)
         {


### PR DESCRIPTION
This PR adds the `add` command, which accepts all todo options:
- `--date`
- `--loc`
- `--tags`

It also moves `RenderTodoList` into a `Renderers` class, which now also includes a `RenderSuccess` and a `RenderError` method, for improved abstraction and reuse.