### PR TITLE
feat(cli): Add `UpdateCommand`

### DIFF
--- a/Tsk.CLI/Application/Commands/UpdateCommand.cs
+++ b/Tsk.CLI/Application/Commands/UpdateCommand.cs
@@ -1,0 +1,147 @@
+using Spectre.Console.Cli;
+using Tsk.Domain.Factories;
+using Tsk.CLI.Application.Settings;
+using Tsk.CLI.Presentation;
+using System.ComponentModel;
+using Tsk.Domain.Entities;
+using Tsk.Domain.Validators;
+using Spectre.Console;
+using Tsk.CLI.Utils;
+
+namespace Tsk.CLI.Application.Commands
+{
+    public class UpdateCommand(ITodoRepositoryFactory factory) : BaseCommand<UpdateCommand.Settings>
+    {
+        private readonly ITodoRepositoryFactory _factory = factory;
+
+        public sealed class Settings : BaseCommandSettings
+        {
+            [Description("ID of todo to update")]
+            [CommandArgument(0, "<id>")]
+            public string Id { get; set; } = string.Empty;
+
+            [Description("Update the todo description")]
+            // [CommandOption("--desc")]
+            [CommandArgument(1, "[description]")]
+            public string Description { get; set; } = string.Empty;
+
+            [Description($"Update the todo due date in yyyyMMdd format, e.g. 20250501")]
+            [CommandOption("-d|--date")]
+            public string? DueDate { get; set; }
+
+            [Description("Update the todo location")]
+            [CommandOption("-l|--loc")]
+            public string? Location { get; set; }
+
+            [Description("Update the todo tags in a comma-separated list")]
+            [CommandOption("-t|--tags")]
+            public string? UpdateTags { get; set; }
+
+            [Description("Add tag(s) in a comma-separated list")]
+            [CommandOption("--add-tags|--add-tag")]
+            public string? AddTags { get; set; }
+
+            [Description("Remove tag(s) in a comma-separated list")]
+            [CommandOption("--remove-tag|--remove-tags")]
+            public string? RemoveTags { get; set; }
+        }
+
+        public override int Execute(CommandContext context, Settings settings)
+        {
+            InitRepository(settings.FileName, _factory);
+            try
+            {
+                InputValidators.ValidateIdString(settings.Id);
+                CommandValidators.ValidateTagOptions(settings);
+                var todo = Repo.GetById(int.Parse(settings.Id))!;
+
+                UpdateDescription(settings, todo);
+                UpdateLocation(settings, todo);
+                UpdateTags(settings, todo);
+                AddTags(settings, todo);
+                RemoveTags(settings, todo);
+                UpdateDueDate(settings, todo);
+
+                Repo.Save(todo);
+                Renderers.RenderSuccess($":floppy_disk: Updated todo \"{todo.Id}\"");
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                Renderers.RenderError(ex.Message);
+                return 1;
+            }
+        }
+
+        private static void UpdateDescription(Settings settings, TodoItem todo)
+        {
+            if (!string.IsNullOrEmpty(settings.Description))
+            {
+                InputValidators.ValidateDescription(settings.Description);
+                todo.UpdateDescription(settings.Description);
+            }
+        }
+
+        private static void UpdateLocation(Settings settings, TodoItem todo)
+        {
+            if (!string.IsNullOrEmpty(settings.Location))
+            {
+                InputValidators.ValidateLocation(settings.Location);
+                todo.UpdateLocation(settings.Location);
+            }
+        }
+
+        private static void UpdateTags(Settings settings, TodoItem todo)
+        {
+            if (!string.IsNullOrEmpty(settings.UpdateTags))
+            {
+                var updatedTags = Parsers.ParseTagsFromString(settings.UpdateTags);
+                foreach (var t in updatedTags)
+                    todo.AddTag(t);
+                List<Tag> tagsToRemove = new();
+                foreach (var t in todo.Tags)
+                    if (!updatedTags.Any(u => u.Name == t.Name))
+                        tagsToRemove.Add(t);
+                foreach (var t in tagsToRemove)
+                    todo.RemoveTag(t);
+            }
+        }
+
+        private static void AddTags(Settings settings, TodoItem todo)
+        {
+            if (!string.IsNullOrEmpty(settings.AddTags))
+            {
+                var newTags = Parsers.ParseTagsFromString(settings.AddTags);
+                foreach (var t in newTags)
+                    todo.AddTag(t);
+            }
+        }
+
+        private static void RemoveTags(Settings settings, TodoItem todo)
+        {
+            if (!string.IsNullOrEmpty(settings.RemoveTags))
+            {
+                var removeTags = Parsers.ParseTagsFromString(settings.RemoveTags);
+                List<Tag> tagsToRemove = new();
+                foreach (var t in todo.Tags)
+                {
+                    if (removeTags.Any(u => u.Name == t.Name))
+                        tagsToRemove.Add(t);
+                }
+                foreach (var t in tagsToRemove)
+                {
+                    todo.RemoveTag(t);
+                }
+            }
+        }
+
+        private static void UpdateDueDate(Settings settings, TodoItem todo)
+        {
+            if (settings.DueDate is not null)
+            {
+                InputValidators.ValidateDateString(settings.DueDate);
+                todo.UpdateDueDate(Parsers.ParseDateFromString(settings.DueDate));
+            }
+        }
+    }
+}

--- a/Tsk.CLI/Program.cs
+++ b/Tsk.CLI/Program.cs
@@ -59,6 +59,11 @@ class Program
                 .WithExample("incomplete 1")
                 .WithExample("o 1")
                 .WithExample("uncheck 1");
+
+            config.AddCommand<UpdateCommand>("update")
+                .WithDescription("Update a todo")
+                .WithAlias("u")
+                .WithExample("update 1 --desc \"fix typos in resume\" --loc home");
         });
         return app.Run(args);
     }

--- a/Tsk.CLI/Utils/CommandValidators.cs
+++ b/Tsk.CLI/Utils/CommandValidators.cs
@@ -1,0 +1,22 @@
+using Tsk.CLI.Application.Commands;
+
+namespace Tsk.CLI.Utils
+{
+    public class CommandValidators
+    {
+        public static void ValidateTagOptions(UpdateCommand.Settings settings)
+        {
+            string?[] tagOptions = {
+                settings.UpdateTags,
+                settings.AddTags,
+                settings.RemoveTags
+            };
+            int tagOptionsSet = 0;
+            foreach (var t in tagOptions)
+                if (!string.IsNullOrEmpty(t)) tagOptionsSet++;
+
+            if (tagOptionsSet > 1)
+                throw new ArgumentException("Please choose one of `--tags`, `--add-tags` or `--remove-tags`.");
+        }
+    }
+}

--- a/Tsk.CLI/Utils/Parsers.cs
+++ b/Tsk.CLI/Utils/Parsers.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Tsk.Domain.Entities;
+
+namespace Tsk.CLI.Utils
+{
+    public class Parsers
+    {
+        public static DateOnly ParseDateFromString(string dateString) =>
+            new(
+                int.Parse(dateString.Substring(0, 4)),
+                int.Parse(dateString.Substring(4, 2)),
+                int.Parse(dateString.Substring(6, 2))
+            );
+
+        public static IEnumerable<Tag> ParseTagsFromString(string tagsString) =>
+            tagsString.Split(",").Select(t => new Tag(t.Trim()));
+    }
+}

--- a/Tsk.Domain/Entities/TodoItem.cs
+++ b/Tsk.Domain/Entities/TodoItem.cs
@@ -40,7 +40,7 @@ namespace Tsk.Domain.Entities
         public IReadOnlyList<Tag> Tags { get => _tags; }
         public void AddTag(Tag tag)
         {
-            if (!Tags.Any(t => t.Name == tag.Name)) _tags.Add(tag);
+            if (!_tags.Any(t => t.Name == tag.Name)) _tags.Add(tag);
         }
         public void RemoveTag(Tag tag) =>
             _tags.RemoveAll(t => t.Name == tag.Name);

--- a/Tsk.Tests/CliUtils/ValidatorsTests.ValidateTagOptions.cs
+++ b/Tsk.Tests/CliUtils/ValidatorsTests.ValidateTagOptions.cs
@@ -1,0 +1,61 @@
+using Tsk.CLI.Utils;
+using Tsk.CLI.Application.Commands;
+
+namespace Tsk.Tests.CliUtils
+{
+    public class ValidatorsTests_ValidateTagOptions
+    {
+        [Fact]
+        public void ShouldNotError_With_UpdateTagsOption()
+        {
+            var settings = new UpdateCommand.Settings();
+            settings.UpdateTags = "jogging";
+            try
+            {
+                CommandValidators.ValidateTagOptions(settings);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Expected no error, but got: " + ex.Message);
+            }
+        }
+
+        [Fact]
+        public void ShouldNotError_With_AddTagsOption()
+        {
+            var settings = new UpdateCommand.Settings();
+            settings.AddTags = "jogging";
+            try
+            {
+                CommandValidators.ValidateTagOptions(settings);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Expected no error, but got: " + ex.Message);
+            }
+        }
+
+        [Fact]
+        public void ShouldNotError_With_NoTagOptions()
+        {
+            var settings = new UpdateCommand.Settings();
+            try
+            {
+                CommandValidators.ValidateTagOptions(settings);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Expected no error, but got: " + ex.Message);
+            }
+        }
+
+        [Fact]
+        public void ShouldError_With_TwoTagOptions()
+        {
+            var settings = new UpdateCommand.Settings();
+            settings.AddTags = "add,tags";
+            settings.RemoveTags = "remove";
+            Assert.Throws<ArgumentException>(() => CommandValidators.ValidateTagOptions(settings));
+        }
+    }
+}


### PR DESCRIPTION
This PR implements the `UpdateCommand` with the following changes:
- add `UpdateCommand` with updating:
  - description
  - location
  - duedate
  - tags (via `--tags`, `--add-tags`, and `--remove-tags`)
- add `CommandValidators` with
  - `ValidateTagOptions`, which enforces only one tag update option
- `Tsk.CLI.Utils.Parers` for parsing tag strings into `List<Tag>`