### PR TITLE
chore: Add release action; make command naming more consistent

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build_and_test:
-    name: build-and-test-${{ matrix.os }}
+    name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+name: build and release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    name: build binaries
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            rid: linux-x64
+            ext: ""
+            archive_ext: tar.gz
+          - os: ubuntu-latest
+            rid: linux-arm64
+            ext: ""
+            archive_ext: tar.gz
+          - os: macos-latest
+            rid: osx-x64
+            ext: ""
+            archive_ext: tar.gz
+          - os: macos-latest
+            rid: osx-arm64
+            ext: ""
+            archive_ext: tar.gz
+          - os: windows-latest
+            rid: win-x64
+            ext: ".exe"
+            archive_ext: zip
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Publish binary
+        run: |
+          dotnet publish src/Tsk.CLI/Tsk.CLI.csproj \
+            -c Release \
+            -r ${{ matrix.rid }} \
+            --self-contained true \
+            /p:PublishSingleFile=true \
+            /p:IncludeNativeLibrariesForSelfExtract=true \
+            /p:EnableCompressionInSingleFile=true \
+            /p:DebugType=none \
+            -o publish
+
+      - name: Rename binary
+        run: mv publish/Tsk.CLI${{ matrix.ext }} tsk-${{ matrix.rid }}${{ matrix.ext }}
+
+      - name: Compress binary (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          tar -czvf tsk-${{ matrix.rid }}.${{ matrix.archive_ext }} tsk-${{ matrix.rid }}
+
+      - name: Compress binary (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          powershell Compress-Archive -Path tsk-${{ matrix.rid }}.exe -DestinationPath tsk-${{ matrix.rid }}.zip
+
+      - name: Upload Release Asset
+        uses: softprops/action-gh-release@v1
+        with:
+          files: tsk-${{ matrix.rid }}.${{ matrix.archive_ext }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/Tsk.CLI/Program.cs
+++ b/src/Tsk.CLI/Program.cs
@@ -44,7 +44,7 @@ class Program
 
             config.AddCommand<CompleteCommand>("complete")
                 .WithDescription("Mark a todo as completed")
-                .WithAlias("c")
+                .WithAlias("done")
                 .WithAlias("check")
                 .WithAlias("x")
                 .WithExample("complete 1")
@@ -53,7 +53,7 @@ class Program
 
             config.AddCommand<IncompleteCommand>("incomplete")
                 .WithDescription("Mark a todo as not completed")
-                .WithAlias("i")
+                .WithAlias("notdone")
                 .WithAlias("uncheck")
                 .WithAlias("o")
                 .WithExample("incomplete 1")


### PR DESCRIPTION
This PR adds the GitHub Action for automated releasing on version tags. It also renames the build-and-release action filename to make it more informative.

It also reworks some of the CLI command naming and aliases to make them more consistent.