### PR TITLE
feat(tests): Add tests for `Tsk.CLI` commands

### DIFF
--- a/src/Tsk.CLI/Application/Commands/AddCommand.cs
+++ b/src/Tsk.CLI/Application/Commands/AddCommand.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using Tsk.Domain.Entities;
 using Tsk.Domain.Validators;
 using Spectre.Console;
+using Tsk.CLI.Utils;
 
 namespace Tsk.CLI.Application.Commands
 {
@@ -58,10 +59,7 @@ namespace Tsk.CLI.Application.Commands
                 if (settings.DueDate is not null)
                 {
                     InputValidators.ValidateDateString(settings.DueDate);
-                    var yyyy = int.Parse(settings.DueDate.Substring(0, 4));
-                    var MM = int.Parse(settings.DueDate.Substring(4, 2));
-                    var dd = int.Parse(settings.DueDate.Substring(6, 2));
-                    todo.UpdateDueDate(new DateOnly(yyyy, MM, dd));
+                    todo.UpdateDueDate(Parsers.ParseDateFromString(settings.DueDate));
                 }
 
                 Repo.Add(todo);

--- a/src/Tsk.CLI/Application/Commands/ListCommand.cs
+++ b/src/Tsk.CLI/Application/Commands/ListCommand.cs
@@ -21,8 +21,7 @@ namespace Tsk.CLI.Application.Commands
             }
             catch (Exception ex)
             {
-
-                System.Console.WriteLine(ex.Message);
+                Console.WriteLine(ex.Message);
                 return 1;
             }
         }

--- a/src/Tsk.CLI/Application/Commands/UpdateCommand.cs
+++ b/src/Tsk.CLI/Application/Commands/UpdateCommand.cs
@@ -5,7 +5,6 @@ using Tsk.CLI.Presentation;
 using System.ComponentModel;
 using Tsk.Domain.Entities;
 using Tsk.Domain.Validators;
-using Spectre.Console;
 using Tsk.CLI.Utils;
 
 namespace Tsk.CLI.Application.Commands
@@ -84,26 +83,44 @@ namespace Tsk.CLI.Application.Commands
 
         private static void UpdateLocation(Settings settings, TodoItem todo)
         {
-            if (!string.IsNullOrEmpty(settings.Location))
+            if (settings.Location is not null)
             {
-                InputValidators.ValidateLocation(settings.Location);
-                todo.UpdateLocation(settings.Location);
+                if (settings.Location == string.Empty)
+                {
+                    todo.UpdateLocation(null);
+                }
+                else
+                {
+                    InputValidators.ValidateLocation(settings.Location);
+                    todo.UpdateLocation(settings.Location);
+                }
             }
         }
 
         private static void UpdateTags(Settings settings, TodoItem todo)
         {
-            if (!string.IsNullOrEmpty(settings.UpdateTags))
+            if (settings.UpdateTags is not null)
             {
-                var updatedTags = Parsers.ParseTagsFromString(settings.UpdateTags);
-                foreach (var t in updatedTags)
-                    todo.AddTag(t);
-                List<Tag> tagsToRemove = new();
-                foreach (var t in todo.Tags)
-                    if (!updatedTags.Any(u => u.Name == t.Name))
-                        tagsToRemove.Add(t);
-                foreach (var t in tagsToRemove)
-                    todo.RemoveTag(t);
+                if (settings.UpdateTags == string.Empty)
+                {
+                    var allTags = todo.Tags.ToList();
+                    foreach (var t in allTags)
+                    {
+                        todo.RemoveTag(t);
+                    }
+                }
+                else if (!string.IsNullOrEmpty(settings.UpdateTags))
+                {
+                    var updatedTags = Parsers.ParseTagsFromString(settings.UpdateTags);
+                    foreach (var t in updatedTags)
+                        todo.AddTag(t);
+                    List<Tag> tagsToRemove = new();
+                    foreach (var t in todo.Tags)
+                        if (!updatedTags.Any(u => u.Name == t.Name))
+                            tagsToRemove.Add(t);
+                    foreach (var t in tagsToRemove)
+                        todo.RemoveTag(t);
+                }
             }
         }
 
@@ -137,7 +154,11 @@ namespace Tsk.CLI.Application.Commands
 
         private static void UpdateDueDate(Settings settings, TodoItem todo)
         {
-            if (settings.DueDate is not null)
+            if (settings.DueDate == string.Empty)
+            {
+                todo.UpdateDueDate(null);
+            }
+            else if (settings.DueDate is not null)
             {
                 InputValidators.ValidateDateString(settings.DueDate);
                 todo.UpdateDueDate(Parsers.ParseDateFromString(settings.DueDate));

--- a/src/Tsk.Domain/Entities/TodoItem.cs
+++ b/src/Tsk.Domain/Entities/TodoItem.cs
@@ -32,8 +32,15 @@ namespace Tsk.Domain.Entities
         public string? Location { get; private set; } = null;
         public void UpdateLocation(string? location)
         {
-            InputValidators.ValidateLocation(location ?? "");
-            Location = location;
+            if (string.IsNullOrEmpty(location))
+            {
+                Location = null;
+            }
+            else
+            {
+                InputValidators.ValidateLocation(location);
+                Location = location;
+            }
         }
 
         private List<Tag> _tags = new();

--- a/src/Tsk.Infrastructure/Repositories/FlatFileTodoRepository.cs
+++ b/src/Tsk.Infrastructure/Repositories/FlatFileTodoRepository.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
 using Tsk.Domain.Entities;
 using Tsk.Domain.Repositories;
 using Tsk.Domain.Serialization;

--- a/tests/Tsk.CLI.Tests/Application/Commands/AddCommandTests.cs
+++ b/tests/Tsk.CLI.Tests/Application/Commands/AddCommandTests.cs
@@ -1,0 +1,39 @@
+using Bogus;
+using Moq;
+using Tsk.CLI.Application.Commands;
+using Tsk.Domain.Factories;
+using Tsk.Domain.Repositories;
+using Tsk.Domain.Entities;
+
+namespace Tsk.CLI.Tests.Application.Commands;
+
+public class AddCommandTests
+{
+    private readonly static Faker f = new();
+
+    [Fact]
+    public void Execute_WithValidDescription_AddsTodo_ReturnsZero()
+    {
+        var id = f.Random.Int(1, 1000);
+        var filename = f.System.FileName();
+        var description = string.Join(" ", f.Lorem.Words(3));
+        var mockRepo = new Mock<ITodoRepository>();
+        mockRepo.Setup(r => r.GetAll()).Returns(new List<TodoItem>());
+
+        var mockFactory = new Mock<ITodoRepositoryFactory>();
+        mockFactory.Setup(f => f.Create(It.IsAny<string?>()!)).Returns(mockRepo.Object);
+
+        var cmd = new AddCommand(mockFactory.Object);
+
+        var settings = new AddCommand.Settings
+        {
+            Description = description,
+            FileName = filename,
+        };
+
+        var result = cmd.Execute(null!, settings);
+
+        Assert.Equal(0, result);
+        mockRepo.Verify(r => r.Add(It.Is<TodoItem>(t => t.Description == description)), Times.Once);
+    }
+}

--- a/tests/Tsk.CLI.Tests/Application/Commands/CompleteCommandTests.cs
+++ b/tests/Tsk.CLI.Tests/Application/Commands/CompleteCommandTests.cs
@@ -1,0 +1,41 @@
+using Bogus;
+using Moq;
+using Tsk.CLI.Application.Commands;
+using Tsk.Domain.Factories;
+using Tsk.Domain.Repositories;
+using Tsk.Domain.Entities;
+
+namespace Tsk.CLI.Tests.Application.Commands;
+
+public class CompleteCommandTests
+{
+    private static readonly Faker f = new();
+
+    [Fact]
+    public void Execute_MarksComplete_ReturnsZero()
+    {
+        var fileName = f.System.FileName();
+        var id = f.Random.Int(1, 1000);
+        var description = string.Join(" ", f.Lorem.Words(3));
+        var mockRepo = new Mock<ITodoRepository>();
+        var fakeTodo = new TodoItem(id: id, description: description);
+        mockRepo.Setup(f => f.GetById(It.Is<int>(s => s == id))).Returns(fakeTodo);
+
+        var mockFactory = new Mock<ITodoRepositoryFactory>();
+        mockFactory.Setup(f => f.Create(It.IsAny<string?>()!)).Returns(mockRepo.Object);
+
+
+        var cmd = new CompleteCommand(mockFactory.Object);
+
+        var settings = new CompleteCommand.Settings
+        {
+            Id = id.ToString(),
+            FileName = fileName,
+        };
+
+        var result = cmd.Execute(null!, settings);
+
+        Assert.Equal(0, result);
+        mockRepo.Verify(r => r.Save(It.Is<TodoItem>(s => s.Completed == true)), Times.Once);
+    }
+}

--- a/tests/Tsk.CLI.Tests/Application/Commands/DeleteCommandTests.cs
+++ b/tests/Tsk.CLI.Tests/Application/Commands/DeleteCommandTests.cs
@@ -1,0 +1,41 @@
+using Bogus;
+using Moq;
+using Tsk.CLI.Application.Commands;
+using Tsk.Domain.Factories;
+using Tsk.Domain.Repositories;
+using Tsk.Domain.Entities;
+
+namespace Tsk.CLI.Tests.Application.Commands;
+
+public class DeleteCommandTests
+{
+    private static readonly Faker f = new();
+
+    [Fact]
+    public void Execute_DeletesTodo_ReturnsZero()
+    {
+        var fileName = f.System.FileName();
+        var id = f.Random.Int(1, 1000);
+        var description = string.Join(" ", f.Lorem.Words(3));
+        var mockRepo = new Mock<ITodoRepository>();
+        var fakeTodo = new TodoItem(id: id, description: description);
+        mockRepo.Setup(f => f.GetById(It.Is<int>(s => s == id))).Returns(fakeTodo);
+
+        var mockFactory = new Mock<ITodoRepositoryFactory>();
+        mockFactory.Setup(f => f.Create(It.IsAny<string?>()!)).Returns(mockRepo.Object);
+
+
+        var cmd = new DeleteCommand(mockFactory.Object);
+
+        var settings = new DeleteCommand.Settings
+        {
+            Id = id.ToString(),
+            FileName = fileName,
+        };
+
+        var result = cmd.Execute(null!, settings);
+
+        Assert.Equal(0, result);
+        mockRepo.Verify(r => r.Delete(It.Is<TodoItem>(s => s.Id == id)), Times.Once);
+    }
+}

--- a/tests/Tsk.CLI.Tests/Application/Commands/ListCommandTests.cs
+++ b/tests/Tsk.CLI.Tests/Application/Commands/ListCommandTests.cs
@@ -1,0 +1,37 @@
+using Bogus;
+using Moq;
+using Tsk.CLI.Application.Commands;
+using Tsk.Domain.Factories;
+using Tsk.Domain.Repositories;
+using Tsk.Domain.Entities;
+
+namespace Tsk.CLI.Tests.Application.Commands;
+
+public class ListCommandTests
+{
+    private static readonly Faker f = new();
+
+    [Fact]
+    public void Execute_ListsTodos_ReturnsZero()
+    {
+        var fileName = f.System.FileName();
+        var mockRepo = new Mock<ITodoRepository>();
+        mockRepo.Setup(r => r.GetAll()).Returns(new List<TodoItem>());
+
+        var mockFactory = new Mock<ITodoRepositoryFactory>();
+        mockFactory.Setup(f => f.Create(It.IsAny<string>())).Returns(mockRepo.Object);
+
+        var cmd = new ListCommand(mockFactory.Object);
+
+        var settings = new ListCommand.Settings
+        {
+            FileName = fileName
+        };
+
+        var result = cmd.Execute(null!, settings);
+
+        Assert.Equal(0, result);
+        mockFactory.Verify(f => f.Create(It.Is<string>(s => s.Contains(fileName))));
+        mockRepo.Verify(r => r.GetAll(), Times.Once);
+    }
+}

--- a/tests/Tsk.CLI.Tests/Application/Commands/UpdateCommandTests.cs
+++ b/tests/Tsk.CLI.Tests/Application/Commands/UpdateCommandTests.cs
@@ -1,0 +1,294 @@
+using Bogus;
+using Moq;
+using Tsk.CLI.Application.Commands;
+using Tsk.Domain.Factories;
+using Tsk.Domain.Repositories;
+using Tsk.Domain.Entities;
+using Tsk.TestSupport;
+
+namespace Tsk.CLI.Tests.Application.Commands;
+
+public class UpdateCommandTests
+{
+    private static readonly Faker f = new();
+    private static readonly TodoTestDataGenerator z = new();
+
+    [Fact]
+    public void Execute_WithDescription_UpdatesDescription_ReturnsZero()
+    {
+        var fileName = f.System.FileName();
+        var todo = z.GetFakeTodoItem();
+        var newDescription = string.Join(" ", f.Lorem.Words(3));
+        var mockRepo = new Mock<ITodoRepository>();
+        mockRepo.Setup(f => f.GetById(It.Is<int>(s => s == todo.Id))).Returns(todo);
+
+        var mockFactory = new Mock<ITodoRepositoryFactory>();
+        mockFactory.Setup(f => f.Create(It.IsAny<string?>()!)).Returns(mockRepo.Object);
+
+
+        var cmd = new UpdateCommand(mockFactory.Object);
+
+        var settings = new UpdateCommand.Settings
+        {
+            Id = todo.Id.ToString(),
+            Description = newDescription,
+            FileName = fileName,
+        };
+
+        var result = cmd.Execute(null!, settings);
+
+        Assert.Equal(0, result);
+        mockRepo.Verify(r => r.Save(It.Is<TodoItem>(s => s.Description == newDescription)));
+    }
+
+    [Fact]
+    public void Execute_WithLocation_UpdatesLocation_ReturnsZero()
+    {
+        var fileName = f.System.FileName();
+        var todo = z.GetFakeTodoItem();
+        var newLocation = f.Address.Country();
+        var mockRepo = new Mock<ITodoRepository>();
+        mockRepo.Setup(f => f.GetById(It.Is<int>(s => s == todo.Id))).Returns(todo);
+
+        var mockFactory = new Mock<ITodoRepositoryFactory>();
+        mockFactory.Setup(f => f.Create(It.IsAny<string?>()!)).Returns(mockRepo.Object);
+
+
+        var cmd = new UpdateCommand(mockFactory.Object);
+
+        var settings = new UpdateCommand.Settings
+        {
+            Id = todo.Id.ToString(),
+            FileName = fileName,
+            Location = newLocation,
+        };
+
+        var result = cmd.Execute(null!, settings);
+
+        Assert.Equal(0, result);
+        mockRepo.Verify(r => r.Save(It.Is<TodoItem>(s => s.Location == newLocation)));
+    }
+
+    [Fact]
+    public void Execute_WithBlankLocation_RemovesLocation_ReturnsZero()
+    {
+        var fileName = f.System.FileName();
+        var todo = z.GetFakeTodoItem();
+        var mockRepo = new Mock<ITodoRepository>();
+        mockRepo.Setup(f => f.GetById(It.Is<int>(s => s == todo.Id))).Returns(todo);
+
+        var mockFactory = new Mock<ITodoRepositoryFactory>();
+        mockFactory.Setup(f => f.Create(It.IsAny<string?>()!)).Returns(mockRepo.Object);
+
+
+        var cmd = new UpdateCommand(mockFactory.Object);
+
+        var settings = new UpdateCommand.Settings
+        {
+            Id = todo.Id.ToString(),
+            FileName = fileName,
+            Location = ""
+        };
+
+        var result = cmd.Execute(null!, settings);
+
+        Assert.Equal(0, result);
+        mockRepo.Verify(r => r.Save(It.Is<TodoItem>(s => string.IsNullOrEmpty(s.Location))));
+    }
+
+    [Fact]
+    public void Execute_WithNoLocation_LeavesLocation_ReturnsZero()
+    {
+        var fileName = f.System.FileName();
+        var todo = z.GetFakeTodoItem();
+        var mockRepo = new Mock<ITodoRepository>();
+        mockRepo.Setup(f => f.GetById(It.Is<int>(s => s == todo.Id))).Returns(todo);
+
+        var mockFactory = new Mock<ITodoRepositoryFactory>();
+        mockFactory.Setup(f => f.Create(It.IsAny<string?>()!)).Returns(mockRepo.Object);
+
+
+        var cmd = new UpdateCommand(mockFactory.Object);
+
+        var settings = new UpdateCommand.Settings
+        {
+            Id = todo.Id.ToString(),
+            FileName = fileName,
+        };
+
+        var result = cmd.Execute(null!, settings);
+
+        Assert.Equal(0, result);
+        mockRepo.Verify(r => r.Save(It.Is<TodoItem>(s => s.Location == todo.Location)));
+    }
+
+    [Fact]
+    public void Execute_WithDueDate_UpdatesDate_ReturnsZero()
+    {
+        var fileName = f.System.FileName();
+        var todo = z.GetFakeTodoItem();
+        var newDate = f.Date.SoonDateOnly();
+        var mockRepo = new Mock<ITodoRepository>();
+        mockRepo.Setup(f => f.GetById(It.Is<int>(s => s == todo.Id))).Returns(todo);
+
+        var mockFactory = new Mock<ITodoRepositoryFactory>();
+        mockFactory.Setup(f => f.Create(It.IsAny<string?>()!)).Returns(mockRepo.Object);
+
+
+        var cmd = new UpdateCommand(mockFactory.Object);
+
+        var settings = new UpdateCommand.Settings
+        {
+            Id = todo.Id.ToString(),
+            DueDate = newDate.ToString("yyyyMMdd"),
+            FileName = fileName,
+        };
+
+        var result = cmd.Execute(null!, settings);
+
+        Assert.Equal(0, result);
+        mockRepo.Verify(r => r.Save(It.Is<TodoItem>(s => s.DueDate == newDate)));
+    }
+
+    [Fact]
+    public void Execute_WithBlankDate_RemovesDate_ReturnsZero()
+    {
+        var fileName = f.System.FileName();
+        var todo = z.GetFakeTodoItem();
+        var mockRepo = new Mock<ITodoRepository>();
+        mockRepo.Setup(f => f.GetById(It.Is<int>(s => s == todo.Id))).Returns(todo);
+
+        var mockFactory = new Mock<ITodoRepositoryFactory>();
+        mockFactory.Setup(f => f.Create(It.IsAny<string?>()!)).Returns(mockRepo.Object);
+
+
+        var cmd = new UpdateCommand(mockFactory.Object);
+
+        var settings = new UpdateCommand.Settings
+        {
+            Id = todo.Id.ToString(),
+            FileName = fileName,
+            DueDate = "",
+        };
+
+        var result = cmd.Execute(null!, settings);
+
+        Assert.Equal(0, result);
+        mockRepo.Verify(r => r.Save(It.Is<TodoItem>(s => s.DueDate == null)));
+    }
+
+    [Fact]
+    public void Execute_WithNoDate_KeepsDate_ReturnsZero()
+    {
+        var fileName = f.System.FileName();
+        var todo = z.GetFakeTodoItem();
+        var mockRepo = new Mock<ITodoRepository>();
+        mockRepo.Setup(f => f.GetById(It.Is<int>(s => s == todo.Id))).Returns(todo);
+
+        var mockFactory = new Mock<ITodoRepositoryFactory>();
+        mockFactory.Setup(f => f.Create(It.IsAny<string?>()!)).Returns(mockRepo.Object);
+
+
+        var cmd = new UpdateCommand(mockFactory.Object);
+
+        var settings = new UpdateCommand.Settings
+        {
+            Id = todo.Id.ToString(),
+            FileName = fileName,
+        };
+
+        var result = cmd.Execute(null!, settings);
+
+        Assert.Equal(0, result);
+        mockRepo.Verify(r => r.Save(It.Is<TodoItem>(s => s.DueDate == todo.DueDate)));
+    }
+
+    [Fact]
+    public void Execute_WithAddTag_AddsTag_ReturnsZero()
+    {
+        var fileName = f.System.FileName();
+        var todo = z.GetFakeTodoItem();
+        var newTag = f.Lorem.Word();
+        var mockRepo = new Mock<ITodoRepository>();
+        mockRepo.Setup(f => f.GetById(It.Is<int>(s => s == todo.Id))).Returns(todo);
+
+        var mockFactory = new Mock<ITodoRepositoryFactory>();
+        mockFactory.Setup(f => f.Create(It.IsAny<string?>()!)).Returns(mockRepo.Object);
+
+
+        var cmd = new UpdateCommand(mockFactory.Object);
+
+        var settings = new UpdateCommand.Settings
+        {
+            Id = todo.Id.ToString(),
+            FileName = fileName,
+            AddTags = newTag,
+        };
+
+        var result = cmd.Execute(null!, settings);
+
+        Assert.Equal(0, result);
+        mockRepo.Verify(r => r.Save(It.Is<TodoItem>(s => s.Tags.Any(t => t.Name == newTag))));
+    }
+
+    [Fact]
+    public void Execute_WithRemoveTag_RemovesTag_ReturnsZero()
+    {
+        var fileName = f.System.FileName();
+        var todo = z.GetFakeTodoItem();
+        var newTag = new Tag(f.Lorem.Word());
+        var tagCount = todo.Tags.Count;
+        var mockRepo = new Mock<ITodoRepository>();
+        todo.AddTag(newTag);
+        mockRepo.Setup(f => f.GetById(It.Is<int>(s => s == todo.Id))).Returns(todo);
+
+        var mockFactory = new Mock<ITodoRepositoryFactory>();
+        mockFactory.Setup(f => f.Create(It.IsAny<string?>()!)).Returns(mockRepo.Object);
+
+
+        var cmd = new UpdateCommand(mockFactory.Object);
+
+        var settings = new UpdateCommand.Settings
+        {
+            Id = todo.Id.ToString(),
+            FileName = fileName,
+            RemoveTags = newTag.Name,
+        };
+
+        var result = cmd.Execute(null!, settings);
+
+        Assert.Equal(0, result);
+        mockRepo.Verify(r => r.Save(It.Is<TodoItem>(s => s.Tags.Count == tagCount && s.Tags.All(t => t.Name != newTag.Name))));
+    }
+
+    [Fact]
+    public void Execute_WithBlankTags_RemovesTags_ReturnsZero()
+    {
+        var fileName = f.System.FileName();
+        var todo = z.GetFakeTodoItem();
+        var tag1 = new Tag(f.Lorem.Word());
+        var tag2 = new Tag(f.Lorem.Word());
+        var mockRepo = new Mock<ITodoRepository>();
+        todo.AddTag(tag1);
+        todo.AddTag(tag2);
+        mockRepo.Setup(f => f.GetById(It.Is<int>(s => s == todo.Id))).Returns(todo);
+
+        var mockFactory = new Mock<ITodoRepositoryFactory>();
+        mockFactory.Setup(f => f.Create(It.IsAny<string?>()!)).Returns(mockRepo.Object);
+
+
+        var cmd = new UpdateCommand(mockFactory.Object);
+
+        var settings = new UpdateCommand.Settings
+        {
+            Id = todo.Id.ToString(),
+            FileName = fileName,
+            UpdateTags = "",
+        };
+
+        var result = cmd.Execute(null!, settings);
+
+        Assert.Equal(0, result);
+        mockRepo.Verify(r => r.Save(It.Is<TodoItem>(s => s.Tags.Count == 0)), Times.Once);
+    }
+}

--- a/tests/Tsk.CLI.Tests/Tsk.CLI.Tests.csproj
+++ b/tests/Tsk.CLI.Tests/Tsk.CLI.Tests.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>

--- a/tests/Tsk.TestSupport/TodoTestDataGenerator.cs
+++ b/tests/Tsk.TestSupport/TodoTestDataGenerator.cs
@@ -1,4 +1,5 @@
 using Bogus;
+using Tsk.Domain.Entities;
 
 namespace Tsk.TestSupport;
 
@@ -33,4 +34,14 @@ public class TodoTestDataGenerator()
         }
         return data;
     }
+
+    public TodoItem GetFakeTodoItem() =>
+        new TodoItem(
+            id: f.Random.Int(1, 1000),
+            description: string.Join(" ", f.Lorem.Words(3)),
+            dueDate: f.Date.SoonDateOnly(),
+            location: f.Address.City(),
+            tags: [new Tag(f.Lorem.Word()), new Tag(string.Join("-", f.Lorem.Words(2)))]
+        );
+
 }

--- a/tests/Tsk.TestSupport/Tsk.TestSupport.csproj
+++ b/tests/Tsk.TestSupport/Tsk.TestSupport.csproj
@@ -10,4 +10,8 @@
     <PackageReference Include="Bogus" Version="35.6.3" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Tsk.Domain\Tsk.Domain.csproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This PR adds tests for all the `Tsk.CLI` commands.

During the course of testing, it was discovered that it was not possible to remove metadata from a todo. This PR, therefore, also adds the ability to do so, by passing a blank string as the argument to the option. E.g.:

```bash
tsk update 1 --loc ""
```